### PR TITLE
slack message change

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -150,3 +150,4 @@ jobs:
           SLACK_USERNAME: bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: ""
+          MSG_MINIMAL: Actions URL, Commit


### PR DESCRIPTION
According to documentation (https://github.com/rtCamp/action-slack-notify) MSG_MINIMAL set to true removes all 4 sub messages (Ref, Event, Actions URL and Commit). As we want to keep action url and commit we can optionally whitelist them by passing it to MSG_MINIMAL.